### PR TITLE
add pl-7 on login/logout buttons on medium screen

### DIFF
--- a/src/components/ui/LogSigUp.jsx
+++ b/src/components/ui/LogSigUp.jsx
@@ -23,14 +23,14 @@ const LogSigUp = (props) => {
     if (str.length <= 10) {
       return str;
     } else {
-      return str.substring(0, 10)+"..";
+      return str.substring(0, 10) + "..";
     }
   }
 
   return (
     <div>
       {isAuth ? (
-        <div className="sm:gap-x-12 sm:text-lg max-w-[236px] text-sm flex text-white justify-between items-center gap-x-4">
+        <div className="md:pl-7 sm:gap-x-12 sm:text-lg max-w-[236px] text-sm flex text-white justify-between items-center gap-x-4">
           <button className="hover:text-[#596c81]" onClick={handleLogout}>
             Logout
           </button>
@@ -41,7 +41,7 @@ const LogSigUp = (props) => {
           </Link>
         </div>
       ) : (
-        <div className="sm:gap-x-12 sm:text-lg max-w-[236px] text-sm flex text-white justify-between items-center gap-x-4">
+        <div className="md:pl-7 sm:gap-x-12 sm:text-lg max-w-[236px] text-sm flex text-white justify-between items-center gap-x-4">
           <Link to="/login" className="hover:text-[#596c81]">
             Login
           </Link>


### PR DESCRIPTION
Fix #28 add padding left of 7 for medium screens (`md:pl-7`) on login/logout buttons in LogSigUp file 
![fixed28](https://github.com/martinyis/RepoAppIdea/assets/69101089/632af2e7-9a01-4357-9b51-fc8fe5f007db)
